### PR TITLE
Allow animateplus as an EmberJS addon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/ember-addon/addon/index.js
+++ b/ember-addon/addon/index.js
@@ -1,0 +1,1 @@
+export default animate;

--- a/ember-addon/index.js
+++ b/ember-addon/index.js
@@ -1,0 +1,23 @@
+'use strict';
+var path      = require('path');
+var Funnel    = require('broccoli-funnel');
+
+module.exports = {
+  name: 'animateplus',
+
+  included: function(app) {
+    this._super.included.apply(this, arguments);
+
+    app.import(path.join(this.treePaths.vendor, 'animateplus', 'animate.min.js'));
+  },
+
+  treeForVendor: function() {
+    var animateplusDir = path.resolve(this.root, '..');
+    var animateplusTree = new Funnel(animateplusDir, {
+      destDir: 'animateplus',
+    });
+
+    return animateplusTree;
+  }
+
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "animation",
     "css",
     "svg",
-    "javascript"
+    "javascript",
+    "ember-addon"
   ],
   "author": "Benjamin De Cock <ben@deaxon.com>",
   "license": "MIT",
@@ -20,5 +21,13 @@
     "url": "https://github.com/bendc/animateplus/issues"
   },
   "homepage": "https://github.com/bendc/animateplus",
-  "files": ["LICENSE.md", "animate.js", "animate.min.js"]
+  "files": ["LICENSE.md", "animate.js", "animate.min.js"],
+
+  "ember-addon": {
+    "main": "ember-addon/index.js"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^5.1.5",
+    "broccoli-funnel": "^0.2.3"
+  }
 }


### PR DESCRIPTION
This adds the infrastructure required for animateplus to work as an ember addon