### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ particularly well-suited for mobile.
 
 ## Getting started
 
-`npm install animateplus` or download `animateplus.js` and start animating things:
+`npm install animateplus`, includde via [CDN](https://www.jsdelivr.com/package/npm/animateplus) or download `animateplus.js` and start animating things:
 
 ```javascript
 import animate from "/animateplus.js";


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/animateplus) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.